### PR TITLE
Performance Optimizations

### DIFF
--- a/src/main/java/zgoly/meteorist/commands/TargetNbt.java
+++ b/src/main/java/zgoly/meteorist/commands/TargetNbt.java
@@ -53,8 +53,9 @@ public class TargetNbt extends Command {
     }
 
     private int getNbt() {
-        if (getTargetNbt() == null) return SINGLE_SUCCESS;
-        mc.player.sendMessage(Text.of(getTargetNbt().toString()));
+        NbtCompound targetNbt = getTargetNbt();
+        if (targetNbt == null) return SINGLE_SUCCESS;
+        mc.player.sendMessage(Text.of(targetNbt.toString()));
         return SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/zgoly/meteorist/modules/ZKillaura.java
+++ b/src/main/java/zgoly/meteorist/modules/ZKillaura.java
@@ -68,11 +68,11 @@ public class ZKillaura extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Pre event) {
+        if (mc.player.isDead() || mc.world == null) return;
+        if (onJump.get() && !(mc.player.fallDistance > fallRange.get())) return;
+        if ((int) (mc.player.getAttackCooldownProgress(0.0F) * 17.0F) < 16) return;
         for (Entity entity : mc.world.getEntities()) {
             if (Arrays.asList(targets.get().keySet().toArray()).contains(entity.getType())) {
-                if (mc.player.isDead() || mc.world == null) return;
-                if (onJump.get() && !(mc.player.fallDistance > fallRange.get())) return;
-                if ((int) (mc.player.getAttackCooldownProgress(0.0F) * 17.0F) < 16) return;
                 if (mc.player.distanceTo(entity) <= range.get() && ((LivingEntity)entity).getHealth() > 0 && entity != mc.player) {
                     mc.interactionManager.attackEntity(mc.player, entity);
                     mc.player.swingHand(Hand.MAIN_HAND);

--- a/src/main/java/zgoly/meteorist/utils/Utils.java
+++ b/src/main/java/zgoly/meteorist/utils/Utils.java
@@ -16,8 +16,6 @@ public class Utils {
 
     /** Checks if {@link BlockPos} has collisions with an entity. */
     public static boolean isCollidesEntity(BlockPos b) {
-        if (mc.world == null) return false;
-        for (Entity entity : mc.world.getEntities()) if (new Box(b).intersects(entity.getBoundingBox())) return true;
-        return false;
+        return isCollidesEntity(new Box(b));
     }
 }


### PR DESCRIPTION
- Only run `getTargetNbt()` once and cache result
- In `ZKillAura`, these 3 if statements only need to be evaluated once. Also, if `mc.world` was null, then `mc.world.getEntities()` would throw a NPE. This means that we could reasonably assume that it won't ever be null, as it's never come up as an issue in the past, and remove it, but that's not my call to make.
- Only create `Box` object once and re-use it instead of creating a new one every loop iteration