### PR TITLE
Fix AutoFeed delay, optimize AutoFix

### DIFF
--- a/src/main/java/zgoly/meteorist/modules/AutoFeed.java
+++ b/src/main/java/zgoly/meteorist/modules/AutoFeed.java
@@ -31,7 +31,7 @@ public class AutoFeed extends Module {
 
     private final Setting<Integer> delay = sgGeneral.add(new IntSetting.Builder()
             .name("delay")
-            .description("Delay after sending a command in ticks (20 ticks = 1 sec).")
+            .description("Delay before sending a command in ticks (20 ticks = 1 sec).")
             .defaultValue(20)
             .range(1, 1200)
             .sliderRange(1, 40)
@@ -51,9 +51,11 @@ public class AutoFeed extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        if (timer >= delay.get() && mc.player.getHungerManager().getFoodLevel() <= hungerLevel.get()) {
-            mc.player.sendCommand(feedCommand.get().replace("/", ""));
-            timer = 0;
-        } else timer ++;
+        if (mc.player.getHungerManager().getFoodLevel() <= hungerLevel.get()) {
+            if (timer >= delay.get()) {
+                mc.player.sendCommand(feedCommand.get().replace("/", ""));
+                timer = 0;
+            } else timer++;
+        } else timer = 0;
     }
 }

--- a/src/main/java/zgoly/meteorist/modules/AutoFix.java
+++ b/src/main/java/zgoly/meteorist/modules/AutoFix.java
@@ -71,17 +71,15 @@ public class AutoFix extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        boolean work = false;
         if (timer >= delay.get()) {
             for (ItemStack item : mc.player.getItemsEquipped()) {
                 if (item.getDamage() > 0 && item.getMaxDamage() > 0) {
                     if ((mode.get() == Mode.Default && item.getMaxDamage() - item.getDamage() >= minDurability.get()) || (mode.get() == Mode.Percentage
-                            && (((item.getMaxDamage() - item.getDamage()) * 100) / item.getMaxDamage()) >= minDurabilityPercentage.get())) work = true;
+                            && (((item.getMaxDamage() - item.getDamage()) * 100) / item.getMaxDamage()) >= minDurabilityPercentage.get())) {
+                        mc.player.sendCommand(fixCommand.get().replace("/", ""));
+                        timer = 0;
+                    }
                 }
-            }
-            if (work) {
-                mc.player.sendCommand(fixCommand.get().replace("/", ""));
-                timer = 0;
             }
         } else timer ++;
     }


### PR DESCRIPTION
- `AutoFeed`: Makes the command be sent x ticks after the condition is met instead of being evaluated every x ticks and sending the command immediately.
- `AutoFix`: Remove redundant boolean